### PR TITLE
fix: if the fallback URL is not passed then src shows an empty on HTM…

### DIFF
--- a/dw-image.js
+++ b/dw-image.js
@@ -315,7 +315,7 @@ export class DwImage extends LitElement {
         src=${this.src}
         loading="${this.loading}"
         .disableZoom=${this.disableZoom}
-        onerror="this.onerror=null;this.src='${this.fallBackSrc}'"
+        onerror="this.onerror=null;this.src='${this.fallBackSrc || this.src}'"
       />
       ${this._zoomImageTemplate}
     `;
@@ -368,7 +368,7 @@ export class DwImage extends LitElement {
       </div>
       <div class="zoom-image-wrapper">
         <div class="zoom-image">
-          <img loading="lazy" .title=${this.title} src=${this.zoomSrc || this.src} onerror="this.onerror=null;this.src='${this.fallBackSrc}'" />
+          <img loading="lazy" .title=${this.title} src=${this.zoomSrc || this.src} onerror="this.onerror=null;this.src='${this.fallBackSrc || this.zoomSrc || this.src}'" />
         </div>
       </div>
     </div>`;


### PR DESCRIPTION
…L render.

card link: https://a.kerika.net/acc_4AkDDShTrU2He25uThV8UR/board/brd_2mBzl3SvQkTf7h20y6WRjw/crd_6yOgbY9p7h0UahgNxjceWw