### PR TITLE
feat: add support for alt attribute on image

### DIFF
--- a/dw-image.js
+++ b/dw-image.js
@@ -203,6 +203,10 @@ export class DwImage extends LitElement {
         type: String
       },
 
+      /**
+       * Alternate text for the image
+       * used for accessibility and displayed if the image cannot be loaded.
+       */
       alt: {
         type: String
       }

--- a/dw-image.js
+++ b/dw-image.js
@@ -377,7 +377,7 @@ export class DwImage extends LitElement {
       </div>
       <div class="zoom-image-wrapper">
         <div class="zoom-image">
-          <img loading="lazy" .title=${this.title} src=${this.zoomSrc || this.src} onerror="this.onerror=null;this.src='${this.fallBackSrc || this.zoomSrc || this.src}'" />
+          <img loading="lazy" .title=${this.title} src=${this.zoomSrc || this.src} onerror="this.onerror=null;this.src='${this.fallBackSrc || this.zoomSrc || this.src}'" alt=${this.alt || ''} />
         </div>
       </div>
     </div>`;

--- a/dw-image.js
+++ b/dw-image.js
@@ -202,6 +202,10 @@ export class DwImage extends LitElement {
       fallBackSrc: {
         type: String
       },
+
+      alt: {
+        type: String
+      }
     };
   }
 
@@ -316,6 +320,7 @@ export class DwImage extends LitElement {
         loading="${this.loading}"
         .disableZoom=${this.disableZoom}
         onerror="this.onerror=null;this.src='${this.fallBackSrc || this.src}'"
+        alt=${this.alt || ''}
       />
       ${this._zoomImageTemplate}
     `;


### PR DESCRIPTION
card link: https://app.kerika.net/acc_4AkDDShTrU2He25uThV8UR/board/brd_2mBzl3SvQkTf7h20y6WRjw/crd_3Or2GBU7sBhJak5hRacQws

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `alt` property to the `dw-image` component, allowing users to set alt text for images. Falls back to an empty string when unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->